### PR TITLE
Migrate from Cloudflare Pages to Vercel deployment configuration

### DIFF
--- a/app/entry.server.tsx
+++ b/app/entry.server.tsx
@@ -1,4 +1,4 @@
-import type { AppLoadContext, EntryContext } from '@remix-run/cloudflare';
+import type { AppLoadContext, EntryContext } from '@remix-run/node';
 import { RemixServer } from '@remix-run/react';
 import { isbot } from 'isbot';
 import { renderToReadableStream } from 'react-dom/server';

--- a/package.json
+++ b/package.json
@@ -7,16 +7,14 @@
   "sideEffects": false,
   "type": "module",
   "scripts": {
-    "deploy": "npm run build && wrangler pages deploy",
     "build": "remix vite:build",
     "dev": "remix vite:dev",
     "test": "vitest --run",
     "test:watch": "vitest",
     "lint": "eslint --cache --cache-location ./node_modules/.cache/eslint .",
     "lint:fix": "npm run lint -- --fix",
-    "start": "bindings=$(./bindings.sh) && wrangler pages dev ./build/client $bindings",
+    "start": "remix-serve build/server/index.js",
     "typecheck": "tsc",
-    "typegen": "wrangler types",
     "preview": "pnpm run build && pnpm run start"
   },
   "engines": {

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,10 @@
+{
+  "buildCommand": "pnpm run build",
+  "outputDirectory": "build/client",
+  "framework": "remix",
+  "functions": {
+    "app/entry.server.tsx": {
+      "runtime": "nodejs18.x"
+    }
+  }
+}

--- a/vercel.json
+++ b/vercel.json
@@ -1,10 +1,5 @@
 {
   "buildCommand": "pnpm run build",
   "outputDirectory": "build/client",
-  "framework": "remix",
-  "functions": {
-    "app/entry.server.tsx": {
-      "runtime": "nodejs18.x"
-    }
-  }
+  "framework": "remix"
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,4 +1,4 @@
-import { cloudflareDevProxyVitePlugin as remixCloudflareDevProxy, vitePlugin as remixVitePlugin } from '@remix-run/dev';
+import { vitePlugin as remixVitePlugin } from '@remix-run/dev';
 import UnoCSS from 'unocss/vite';
 import { defineConfig, type ViteDevServer } from 'vite';
 import { nodePolyfills } from 'vite-plugin-node-polyfills';
@@ -14,7 +14,6 @@ export default defineConfig((config) => {
       nodePolyfills({
         include: ['path', 'buffer'],
       }),
-      config.mode !== 'test' && remixCloudflareDevProxy(),
       remixVitePlugin({
         future: {
           v3_fetcherPersist: true,


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Switched deployment from Cloudflare Pages to Vercel, updating configuration files and build scripts for compatibility.

- **Migration**
 - Added vercel.json for deployment settings.
 - Updated server entry to use Remix Node adapter.
 - Removed Cloudflare-specific scripts and plugins from package.json and vite.config.ts.

<!-- End of auto-generated description by cubic. -->

